### PR TITLE
[FLINK-11004][Documentation] wrong ProcessWindowFunction.process argument in window document

### DIFF
--- a/docs/dev/stream/operators/windows.md
+++ b/docs/dev/stream/operators/windows.md
@@ -819,7 +819,7 @@ private static class MyProcessWindowFunction
                     Iterable<SensorReading> minReadings,
                     Collector<Tuple2<Long, SensorReading>> out) {
       SensorReading min = minReadings.iterator().next();
-      out.collect(new Tuple2<Long, SensorReading>(window.getStart(), min));
+      out.collect(new Tuple2<Long, SensorReading>(context.window().getStart(), min));
   }
 }
 
@@ -836,12 +836,12 @@ input
   .reduce(
     (r1: SensorReading, r2: SensorReading) => { if (r1.value > r2.value) r2 else r1 },
     ( key: String,
-      window: TimeWindow,
+      context: Context,
       minReadings: Iterable[SensorReading],
       out: Collector[(Long, SensorReading)] ) =>
       {
         val min = minReadings.iterator.next()
-        out.collect((window.getStart, min))
+        out.collect((context.window.getStart, min))
       }
   )
 


### PR DESCRIPTION

## What is the purpose of the change

*Fix wrong argument of process() in JAVA and Scala example of [Incremental Window Aggregation with ReduceFunction](https://ci.apache.org/projects/flink/flink-docs-release-1.6/dev/stream/operators/windows.html#incremental-window-aggregation-with-reducefunction)*

## Brief change log

  - *Fix wrong argument of process() in JAVA and Scala example of "Incremental Window Aggregation with ReduceFunction"*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
